### PR TITLE
Packaging for Linux, Debian/Ubuntu

### DIFF
--- a/debian/build-pkg.sh
+++ b/debian/build-pkg.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -eu
+
+# # TODO
+#
+# - We currently dig out the version from a git tag, so we can't build from
+#   tarball. Not great.
+#
+# - lintian ./tkey-ssh-agent_0.1-1_amd64.deb
+#   E: tkey-ssh-agent: no-changelog usr/share/doc/tkey-ssh-agent/changelog.Debian.gz (non-native package)
+
+pkgname="tkey-fido"
+debian_revision="1"
+pkgmaintainer="Tillitis <hello@tillitis.se>"
+
+if [[ "$(uname -m)" != "x86_64" ]]; then
+  printf "expecting to build on x86_64, bailing out\n"
+  exit 1
+fi
+
+cd "${0%/*}" || exit 1
+destdir="$PWD/build"
+rm -rf "$destdir"
+mkdir "$destdir"
+
+pushd >/dev/null ..
+
+# upstream_version is the version of the program we're packaging
+upstream_version="$(git describe --dirty --always | sed -n "s/^v\(.*\)/\1/p")"
+if [[ -z "$upstream_version" ]]; then
+  printf "found no tag (with v-prefix) to use for upstream_version\n"
+  exit 1
+fi
+if [[ ! "$upstream_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  printf "%s: repo has commit after last tag, or git tree is dirty\n" "$upstream_version"
+  exit 1
+fi
+pkgversion="$upstream_version-$debian_revision"
+
+make clean
+make -j CGO_ENABLED=0 TKEY_SSH_AGENT_VERSION="$upstream_version" tkey-fido
+make -C apps check-fido-hash
+make DESTDIR="$destdir" \
+     PREFIX=/usr \
+     SYSTEMDDIR=/usr/lib/systemd \
+     UDEVDIR=/usr/lib/udev \
+     install
+
+popd >/dev/null
+
+install -Dm644 deb/copyright "$destdir"/usr/share/doc/tkey-ssh-agent/copyright
+install -Dm644 deb/lintian--overrides "$destdir"/usr/share/lintian/overrides/tkey-ssh-agent
+mkdir "$destdir/DEBIAN"
+cp -af deb/postinst "$destdir/DEBIAN/"
+sed -e "s/##VERSION##/$pkgversion/" \
+    -e "s/##PACKAGE##/$pkgname/" \
+    -e "s/##MAINTAINER##/$pkgmaintainer/" \
+    deb/control.tmpl >"$destdir/DEBIAN/control"
+
+dpkg-deb --root-owner-group -Zgzip --build "$destdir" .
+
+for f in *.deb; do
+  sha512sum "$f" >"$f".sha512
+done

--- a/debian/deb/control.tmpl
+++ b/debian/deb/control.tmpl
@@ -1,0 +1,13 @@
+Section: misc
+Priority: optional
+Maintainer: ##MAINTAINER##
+Package: ##PACKAGE##
+Version: ##VERSION##
+Architecture: amd64
+Depends: pinentry-gnome3 | pinentry
+Homepage: https://github.com/tillitis/tkey-fido
+Description: U2F/FIDO backed by Tillitis TKey
+ tkey-fido 
+
+is an alternative SSH agent backed by a private ed25519 key
+ residing in the hardware TKey, a USB stick.

--- a/debian/deb/copyright
+++ b/debian/deb/copyright
@@ -1,0 +1,5 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Files: *
+Copyright: 2023 Tillitis AB
+License: GPL-2

--- a/debian/deb/lintian--overrides
+++ b/debian/deb/lintian--overrides
@@ -1,0 +1,2 @@
+# Go program linked statically.
+tkey-fido: statically-linked-binary

--- a/debian/deb/postinst
+++ b/debian/deb/postinst
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+    configure)
+        if udevadm --version >/dev/null; then
+            udevadm control --reload || true
+            udevadm trigger --action=add --subsystem-match=tty || true
+        fi
+    ;;
+esac

--- a/system/tkey-fido.service.tmpl
+++ b/system/tkey-fido.service.tmpl
@@ -1,0 +1,26 @@
+[Unit]
+Description=U2F/FIDO for Tillitis TKey
+Documentation=https://github.com/tillitis/tkey-fido
+
+[Service]
+ExecStart=##BINDIR##/tkey-fido --uss
+ExecReload=/usr/bin/kill -HUP $MAINPID
+NoNewPrivileges=yes
+KeyringMode=private
+UMask=0177
+ProtectSystem=strict
+RuntimeDirectory=tkey-fido
+RuntimeDirectoryMode=0700
+ReadWritePaths=/dev /run
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+SystemCallErrorNumber=EPERM
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
- systemd unit - tested, works.
- debian package - untested.

To test systemd unit:

1. edit the system/tkey-fido.service.tmpl and exchange `##BINDIR##` with a path to where you place the tke `tkey-fido` binary.
2. Place the file in ~/.config/systemd/user/tkey-fido.service
3. `systemctl --user enable tkey-fido`
4. `systemctl --user start tkey-fido`

Then test Webauthn auth against https://demo.yubico.com/

To test the Debian package building, on a Debian or Ubuntu box, run:

```
% ./debian/build-pkg.sh
```

You will probably have to tag the repo first, but not need to push the tags.
