### PR TITLE
Update to tkey-libs v0.0.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,28 +21,16 @@ jobs:
           # fetch-depth: 0
           persist-credentials: false
 
-      - name: Clone tkey-libs
-        uses: actions/checkout@v3
-        with:
-          repository: tillitis/tkey-libs
-          ref: main
-          path: tkey-libs
-
       - name: fix
         # https://github.com/actions/runner-images/issues/6775
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Build tkey-libs
-        run: |
-          cd tkey-libs
-          make
-
       - name: make
-        run: make LIBDIR=./tkey-libs
+        run: ./build.sh
 
       - name: check matching fido app hash
-        run: make LIBDIR=./tkey-libs check-fido-hash
+        run: make check-fido-hash
 
       - name: lint go code
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ CFLAGS = -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mcmode
 AS = clang
 ASFLAGS = -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mcmodel=medany -mno-relax
 
-LDFLAGS=-T $(LIBDIR)/app.lds -L $(LIBDIR)/libcommon/ -lcommon -L $(LIBDIR)/libcrt0/ -lcrt0 -L $(LIBDIR)/monocypher -lmonocypher
+LDFLAGS=-T $(LIBDIR)/app.lds -L $(LIBDIR) -lcommon -lcrt0 -lmonocypher
 
 .PHONY: install
 install:
@@ -61,7 +61,7 @@ check-fido-hash: device-fido/app.bin
 FIDOOBJS=device-fido/main.o device-fido/app_proto.o device-fido/rng.o device-fido/p256/p256-m.o device-fido/sha-256/sha-256.o device-fido/u2f.o
 device-fido/app.elf: $(FIDOOBJS)
 	$(CC) $(CFLAGS) $(FIDOOBJS) $(LDFLAGS) -L monocypher -lmonocypher -I monocypher -o $@
-$(FIDOOBJS): $(INCLUDE)/tk1_mem.h device-fido/app_proto.h
+$(FIDOOBJS): $(INCLUDE)/tkey/tk1_mem.h device-fido/app_proto.h
 
 # Uses ../.clang-format
 FMTFILES=device-fido/app_proto.[ch] device-fido/main.c device-fido/u2f.[ch] device-fido/rng.[ch]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ change.
 
 See [Release notes](docs/release_notes.md).
 
+## Building
+
+Use `build.sh` to clone dependencies and build with native tools.
+
+See [Tillitis Developer Handbook](https://dev.tillitis.se/) for tool
+support.
+
 ## fido application protocol
 
 `fido` has a simple protocol on top of the [TKey Framing

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,18 @@
+#! /bin/sh
+
+set -e
+
+tkey_libs_version="v0.0.2"
+printf "Building tkey-libs with version: %s\n" "$tkey_libs_version"
+
+if [ -d ../tkey-libs ]
+then
+    (cd ../tkey-libs; git checkout "$tkey_libs_version")
+else
+    git clone -b "$tkey_libs_version" https://github.com/tillitis/tkey-libs.git ../tkey-libs
+fi
+
+make -j -C ../tkey-libs clean
+make -j -C ../tkey-libs
+
+make

--- a/device-fido/app_proto.c
+++ b/device-fido/app_proto.c
@@ -1,7 +1,7 @@
 // Copyright (C) 2022, 2023 - Tillitis AB
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include <qemu_debug.h>
+#include <tkey/qemu_debug.h>
 
 #include "app_proto.h"
 

--- a/device-fido/app_proto.h
+++ b/device-fido/app_proto.h
@@ -4,8 +4,8 @@
 #ifndef APP_PROTO_H
 #define APP_PROTO_H
 
-#include <lib.h>
-#include <proto.h>
+#include <tkey/lib.h>
+#include <tkey/proto.h>
 
 // TODO lets create #defines for {CMD,RSP}_foo_{LEN,BYTELEN}?
 

--- a/device-fido/main.c
+++ b/device-fido/main.c
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include <monocypher/monocypher-ed25519.h>
-#include <qemu_debug.h>
-#include <tk1_mem.h>
+#include <tkey/qemu_debug.h>
+#include <tkey/tk1_mem.h>
 
 #include "app_proto.h"
 #include "rng.h"

--- a/device-fido/p256/p256-m.h
+++ b/device-fido/p256/p256-m.h
@@ -7,7 +7,8 @@
 #ifndef P256_M_H
 #define P256_M_H
 
-#include <types.h>
+#include <stdint.h>
+#include <stddef.h>
 
 /* Status codes */
 #define P256_SUCCESS            0

--- a/device-fido/rng.c
+++ b/device-fido/rng.c
@@ -6,9 +6,9 @@
 // When loaded and started, this app will continiously generate random data
 // words and send them to the host as a stream of bytes.
 
-#include <blake2s.h>
-#include <lib.h>
-#include <tk1_mem.h>
+#include <tkey/blake2s.h>
+#include <tkey/lib.h>
+#include <tkey/tk1_mem.h>
 
 #include "rng.h"
 

--- a/device-fido/rng.h
+++ b/device-fido/rng.h
@@ -1,7 +1,7 @@
 // Copyright (C) 2023 - Tillitis AB
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include <types.h>
+#include <stdint.h>
 
 void rng_init_state();
 int rng_generate(uint8_t *output, unsigned output_size);

--- a/device-fido/sha-256/sha-256.h
+++ b/device-fido/sha-256/sha-256.h
@@ -5,9 +5,8 @@
 #ifndef SHA_256_H
 #define SHA_256_H
 
-// #include <stdint.h>
-// #include <string.h>
-#include <lib.h>
+#include <stdint.h>
+#include <tkey/lib.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/device-fido/u2f.c
+++ b/device-fido/u2f.c
@@ -1,9 +1,9 @@
 // Copyright (C) 2023 - Tillitis AB
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include <blake2s.h>
-#include <lib.h>
-#include <tk1_mem.h>
+#include <tkey/blake2s.h>
+#include <tkey/lib.h>
+#include <tkey/tk1_mem.h>
 
 #include "p256/p256-m.h"
 #include "sha-256/sha-256.h"

--- a/device-fido/u2f.h
+++ b/device-fido/u2f.h
@@ -1,7 +1,7 @@
 // Copyright (C) 2023 - Tillitis AB
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include <types.h>
+#include <stdint.h>
 
 void u2f_init();
 

--- a/tools/spdx-ensure
+++ b/tools/spdx-ensure
@@ -23,8 +23,6 @@ missingok_files=(
 LICENSE
 Makefile
 README.md
-device-fido/sha-256.c.orig
-device-fido/sha-256.h.orig
 dco.md
 go.mod
 go.sum
@@ -32,7 +30,11 @@ gotools/Makefile
 gotools/go.mod
 gotools/go.sum
 system/60-tkey.rules
-tillitis-ant.png
+device-fido/app.bin.sha512
+device-fido/p256/LICENSE
+device-fido/p256/README.md
+device-fido/sha-256/LICENSE.md
+device-fido/sha-256/README.md
 )
 
 is_missingok() {


### PR DESCRIPTION
tkey-libs now uses ordinary headers.

Merge after https://github.com/tillitis/tkey-libs/pull/16
